### PR TITLE
Test HTTP client driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Miscellaneous.
 *.bak
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,26 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,19 +59,6 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "fnv"
@@ -176,12 +143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,12 +184,12 @@ dependencies = [
 name = "io_drivers"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "hyper",
  "hyper-rustls",
  "log",
  "noun",
  "rustls",
+ "simplelog",
  "tokio",
 ]
 
@@ -302,6 +263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,23 +312,6 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ring"
@@ -452,6 +405,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+
+[[package]]
+name = "simplelog"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +455,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ authors = ["Peter McEvoy <peter@tlon.io>"]
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-env_logger = "0.9"
 hyper = { version = "0.14", features = ["client"], optional = true }
 hyper-rustls = { version = "0.23", optional = true }
 log = { version = "0.4", features = ["release_max_level_warn"] }
 noun = { git = "https://github.com/urbit/noun.git", branch = "master", features = ["thread-safe"] }
 rustls = { version = "0.20", optional = true }
+simplelog = "0.12"
 tokio = { version = "1", features = ["io-std", "io-util", "rt-multi-thread", "sync"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ To build and run the test suite, run:
 $ cargo test
 ```
 
+The test suite includes integration tests, which execute the binary defined by
+`src/main.rs` in a subprocess. Logging output from the binary when executed as a
+subprocess can be captured by defining the `URBIT_IO_DRIVERS_LOG` environment
+variable. For example:
+```console
+$ URBIT_IO_DRIVERS_LOG=test.log cargo test
+```
+Note that each `#[test]` test defined in files in `tests/` will spawn a unique
+version of the binary, which means that logging output will likely be
+interleaved.
+
 To build and view the documentation, run:
 ```console
 $ cargo doc --open

--- a/README.md
+++ b/README.md
@@ -30,14 +30,9 @@ $ cargo test
 
 The test suite includes integration tests, which execute the binary defined by
 `src/main.rs` in a subprocess. Logging output from the binary when executed as a
-subprocess can be captured by defining the `URBIT_IO_DRIVERS_LOG` environment
-variable. For example:
-```console
-$ URBIT_IO_DRIVERS_LOG=test.log cargo test
-```
-Note that each `#[test]` test defined in files in `tests/` will spawn a unique
-version of the binary, which means that logging output will likely be
-interleaved.
+subprocess is captured in `<test_fn_name>.<test_file_name>.log`. For example,
+the logging output from the binary when running the `send_request()` test in
+`tests/http_client_tests.rs` ends up in `send_request.http_client_tests.log`.
 
 To build and view the documentation, run:
 ```console

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -504,32 +504,14 @@ mod tests {
                 Noun::from(Atom::from(req_num)),
                 Noun::from(Atom::from(200u8)),
                 Noun::from(Cell::from([
-                    Noun::from(Cell::from([
-                        Atom::from("server"),
-                        Atom::from("nginx/1.14.0 (Ubuntu)"),
-                    ])),
-                    Noun::from(Cell::from([
-                        Atom::from("date"),
-                        Atom::from("Fri, 08 Jul 2022 16:43:50 GMT"),
-                    ])),
-                    Noun::from(Cell::from([
-                        Atom::from("content-type"),
-                        Atom::from("application/json"),
-                    ])),
-                    Noun::from(Cell::from([
-                        Atom::from("content-length"),
-                        Atom::from("14645"),
-                    ])),
-                    Noun::from(Cell::from([
-                        Atom::from("connection"),
-                        Atom::from("keep-alive"),
-                    ])),
-                    Noun::from(Cell::from([
-                        Atom::from("vary"),
-                        Atom::from("Accept-Encoding"),
-                    ])),
-                    Noun::from(Cell::from([Atom::from("vary"), Atom::from("Origin")])),
-                    Noun::from(Cell::from([Atom::from("x-cached"), Atom::from("HIT")])),
+                    Noun::from(Cell::from(["server", "nginx/1.14.0 (Ubuntu)"])),
+                    Noun::from(Cell::from(["date", "Fri, 08 Jul 2022 16:43:50 GMT"])),
+                    Noun::from(Cell::from(["content-type", "application/json"])),
+                    Noun::from(Cell::from(["content-length", "14645"])),
+                    Noun::from(Cell::from(["connection", "keep-alive"])),
+                    Noun::from(Cell::from(["vary", "Accept-Encoding"])),
+                    Noun::from(Cell::from(["vary", "Origin"])),
+                    Noun::from(Cell::from(["x-cached", "HIT"])),
                     Noun::from(Atom::from(0u8)),
                 ])),
                 Noun::from(Cell::from([

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -608,5 +608,63 @@ mod tests {
             assert_eq!(req.req.uri().path(), "/");
             assert_eq!(req.req.headers().get(header.0).unwrap(), header.1);
         }
+
+        // Malformed request: request number is a cell, not an atom.
+        {
+            let noun = Noun::from(Cell::from([
+                Noun::from(Cell::from([24u8, 7u8])),
+                Noun::null(),
+            ]));
+            assert!(SendRequest::try_from(&noun).is_err());
+        }
+
+        // Malformed request: method is a cell, not an atom.
+        {
+            let noun = Noun::from(Cell::from([
+                Noun::from(Atom::from(57774u16)),
+                Noun::from(Cell::from(["G", "ET"])),
+                Noun::null(),
+            ]));
+            assert!(SendRequest::try_from(&noun).is_err());
+        }
+
+        // Malformed request: uri is cell, not an atom.
+        {
+            let noun = Noun::from(Cell::from([
+                Noun::from(Atom::from(338u16)),
+                Noun::from(Atom::from("PUT")),
+                Noun::from(Cell::from(["https", "://", "urbit.org", "/"])),
+                Noun::null(),
+            ]));
+            assert!(SendRequest::try_from(&noun).is_err());
+        }
+
+        // Malformed request: headers are a list of atoms, not of cells.
+        {
+            let noun = Noun::from(Cell::from([
+                Noun::from(Atom::from(4049991u32)),
+                Noun::from(Atom::from("POST")),
+                Noun::from(Atom::from("https://urbit.org")),
+                Noun::from(Cell::from([
+                    Atom::from("Content-Type"),
+                    Atom::from("application/json"),
+                    Atom::null(),
+                ])),
+                Noun::null(),
+            ]));
+            assert!(SendRequest::try_from(&noun).is_err());
+        }
+
+        // Malformed request: body cell is missing leading null.
+        {
+            let noun = Noun::from(Cell::from([
+                Noun::from(Atom::from(274461u32)),
+                Noun::from(Atom::from("GET")),
+                Noun::from(Atom::from("http://www.lmdb.tech")),
+                Noun::null(),
+                Noun::from(Cell::from([Atom::from(5u8), Atom::from("hello")])),
+            ]));
+            assert!(SendRequest::try_from(&noun).is_err());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-/// Implements `TryFrom<&Noun>` for the request enum of a driver, which enumerates all of the
-/// different types of requests that driver may handle, with minimal boilerplate. A properly
-/// structured noun is:
+/// Implements `TryFrom<&Noun>` for the request enum of a driver.
+///
+/// The request enum of a driver enumerates all of the different types of requests that driver may
+/// handle, with minimal boilerplate. A properly structured noun is:
 ///
 /// ```text
 /// [<tag> <data>]
@@ -69,8 +70,10 @@ macro_rules! impl_try_from_noun_for_request {
 }
 
 #[cfg(feature = "file-system")]
+/// File system.
 pub mod fs;
 #[cfg(feature = "http-client")]
+/// HTTP client and server.
 pub mod http;
 
 use log::{debug, error, info, warn};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 use io_drivers::{http::client::http_client_run, Status};
-use std::env;
+use simplelog::{Config, LevelFilter, WriteLogger};
+use std::{env, fs::File};
+
+/// File to write all logging statements to.
+const LOG_FILE: &'static str = "io_drivers.log";
 
 fn main() -> Status {
     let mut args = env::args();
@@ -8,7 +12,12 @@ fn main() -> Status {
     }
 
     let driver = args.nth(1).unwrap_or(String::from("unknown"));
-    env_logger::init();
+    WriteLogger::init(
+        LevelFilter::Debug,
+        Config::default(),
+        File::create(LOG_FILE).expect("create log file"),
+    )
+    .expect("initialize logger");
     match &driver[..] {
         "http-client" => http_client_run(),
         _ => Status::NoDriver,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,16 @@
-fn main() -> io_drivers::Status {
+use io_drivers::{http::client::http_client_run, Status};
+use std::env;
+
+fn main() -> Status {
+    let mut args = env::args();
+    if args.len() != 2 {
+        return Status::NoDriver;
+    }
+
+    let driver = args.nth(1).unwrap_or(String::from("unknown"));
     env_logger::init();
-    io_drivers::http::client::http_client_run()
+    match &driver[..] {
+        "http-client" => http_client_run(),
+        _ => Status::NoDriver,
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,6 @@ use io_drivers::{http::client::http_client_run, Status};
 use simplelog::{Config, LevelFilter, WriteLogger};
 use std::{env, fs::File};
 
-/// File to write all logging statements to.
-const LOG_FILE: &'static str = "io_drivers.log";
-
 fn main() -> Status {
     let mut args = env::args();
     if args.len() != 2 {
@@ -12,12 +9,18 @@ fn main() -> Status {
     }
 
     let driver = args.nth(1).unwrap_or(String::from("unknown"));
-    WriteLogger::init(
-        LevelFilter::Debug,
-        Config::default(),
-        File::create(LOG_FILE).expect("create log file"),
-    )
-    .expect("initialize logger");
+    if let Ok(log) = env::var("URBIT_IO_DRIVERS_LOG") {
+        WriteLogger::init(
+            LevelFilter::Debug,
+            Config::default(),
+            File::options()
+                .create(true)
+                .append(true)
+                .open(log)
+                .expect("create log file"),
+        )
+        .expect("initialize logger");
+    }
     match &driver[..] {
         "http-client" => http_client_run(),
         _ => Status::NoDriver,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,19 +4,23 @@ use noun::{
 };
 use std::{
     io::{Read, Write},
+    path::Path,
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
 };
 
 /// Spawns an IO driver in a subprocess with piped `stdin` and `stdout`.
-pub(crate) fn spawn_driver(driver: &'static str) -> Child {
+pub(crate) fn spawn_driver(driver: &'static str, log_file: &Path) -> Child {
     // Absolute path to the binary defined by `src/main.rs`.
     const BINARY: &'static str = env!("CARGO_BIN_EXE_io_drivers");
+
+    const LOG_VAR: &'static str = "URBIT_IO_DRIVERS_LOG";
 
     Command::new(BINARY)
         .arg(driver)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
+        .env(LOG_VAR, log_file)
         .spawn()
         .expect("spawn io_drivers process")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,68 @@
+use noun::{
+    serdes::{Cue, Jam},
+    Atom, Noun,
+};
+use std::{
+    io::{Read, Write},
+    mem::size_of,
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+};
+
+/// Spawns an IO driver in a subprocess with piped `stdin` and `stdout`.
+pub(crate) fn spawn_driver(driver: &'static str) -> Child {
+    // Absolute path to the binary defined by `src/main.rs`.
+    const BINARY: &'static str = env!("CARGO_BIN_EXE_io_drivers");
+
+    Command::new(BINARY)
+        .arg(driver)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn io_drivers process")
+}
+
+/// Writes a request to a driver's input source.
+pub(crate) fn write_request(input: &mut ChildStdin, req: Noun) {
+    let req = req.jam().into_vec();
+
+    // Write the little-endian request length.
+    assert!(req.len() >= size_of::<u64>());
+    let len = req.len().to_le_bytes();
+    input.write_all(&len[..]).expect("write request length");
+
+    // Write the request.
+    input.write_all(&req[..]).expect("write request");
+    input.flush().expect("flush input");
+}
+
+/// Reads a response from a driver's output sink.
+pub(crate) fn read_response(output: &mut ChildStdout) -> Noun {
+    // Read the little-endian response length.
+    let mut len: [u8; 8] = [0; 8];
+    output
+        .read_exact(&mut len[..])
+        .expect("read response length");
+    let len = usize::try_from(u64::from_le_bytes(len)).expect("u64 to usize");
+
+    // Read the response.
+    let mut resp = Vec::with_capacity(len);
+    // Extend the length to match the capacity.
+    resp.resize(resp.capacity(), 0);
+    output.read_exact(&mut resp[..]).expect("read response");
+
+    Cue::cue(Atom::from(resp)).expect("cue response")
+}
+
+/// Compares a [`Noun`] to a `u64`, returning `true` if they represent the same value and `false`
+/// otherwise.
+pub(crate) fn check_u64(actual: &Noun, expected: u64) -> bool {
+    if let Noun::Atom(actual) = actual {
+        if let Some(actual) = actual.as_u64() {
+            actual == expected
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+//! Utilities shared by integration tests.
+
 use noun::{
     serdes::{Cue, Jam},
     Atom, Noun,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,6 @@ use noun::{
 };
 use std::{
     io::{Read, Write},
-    mem::size_of,
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
 };
 
@@ -17,6 +16,7 @@ pub(crate) fn spawn_driver(driver: &'static str) -> Child {
         .arg(driver)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
         .spawn()
         .expect("spawn io_drivers process")
 }
@@ -26,7 +26,6 @@ pub(crate) fn write_request(input: &mut ChildStdin, req: Noun) {
     let req = req.jam().into_vec();
 
     // Write the little-endian request length.
-    assert!(req.len() >= size_of::<u64>());
     let len = req.len().to_le_bytes();
     input.write_all(&len[..]).expect("write request length");
 

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -5,14 +5,17 @@
 //! pipe.
 
 use noun::{convert, Atom, Cell, Noun};
-use std::{sync::mpsc, thread, time::Duration};
+use std::{path::Path, sync::mpsc, thread, time::Duration};
 
 mod common;
 
 /// Sends `%request` requests to the HTTP client driver.
 #[test]
 fn send_request() {
-    let mut driver = common::spawn_driver("http-client");
+    let mut driver = common::spawn_driver(
+        "http-client",
+        Path::new("send_request.http_client_tests.log"),
+    );
 
     let mut input = driver.stdin.take().unwrap();
     let mut output = driver.stdout.take().unwrap();
@@ -173,7 +176,10 @@ fn send_request() {
 
 #[test]
 fn cancel_request() {
-    let mut driver = common::spawn_driver("http-client");
+    let mut driver = common::spawn_driver(
+        "http-client",
+        Path::new("cancel_request.http_client_tests.log"),
+    );
 
     let mut input = driver.stdin.take().unwrap();
     let mut output = driver.stdout.take().unwrap();

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -18,8 +18,8 @@ fn send_request() {
         Path::new("send_request.http_client_tests.log"),
     );
 
-    let mut input = driver.stdin.take().unwrap();
-    let mut output = driver.stdout.take().unwrap();
+    let mut input = driver.0.stdin.take().unwrap();
+    let mut output = driver.0.stdout.take().unwrap();
 
     // This HTTP request can be replicated from the command line:
     //
@@ -182,8 +182,8 @@ fn cancel_request() {
         Path::new("cancel_request.http_client_tests.log"),
     );
 
-    let mut input = driver.stdin.take().unwrap();
-    let mut output = driver.stdout.take().unwrap();
+    let mut input = driver.0.stdin.take().unwrap();
+    let mut output = driver.0.stdout.take().unwrap();
 
     {
         let req_num = 1443u16;

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -1,8 +1,9 @@
-//! Tests the HTTP client driver. The general pattern for each test is to launch the HTTP client
-//! driver in a subprocess with piped `stdin` and `stdout` via the crate's
-//! binary (defined in `src/main.rs`) and write HTTP client requests to the driver over the
-//! subprocess's `stdin` pipe and read responses to those requests over the subprocess's `stdout`
-//! pipe.
+//! Tests the HTTP client driver.
+//!
+//! The general pattern for each test is to launch the HTTP client driver in a subprocess with piped
+//! `stdin` and `stdout` via the crate's binary (defined in `src/main.rs`) and write HTTP client
+//! requests to the driver over the subprocess's `stdin` pipe and read responses to those requests
+//! over the subprocess's `stdout` pipe.
 
 use noun::{convert, Atom, Cell, Noun};
 use std::{path::Path, sync::mpsc, thread, time::Duration};

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -1,0 +1,176 @@
+//! Tests the HTTP client driver. The general pattern for each test is to launch the HTTP client
+//! driver in a subprocess with piped `stdin` and `stdout` via the crate's
+//! binary (defined in `src/main.rs`) and write HTTP client requests to the driver over the
+//! subprocess's `stdin` pipe and read responses to those requests over the subprocess's `stdout`
+//! pipe.
+
+use noun::{convert, Atom, Cell, Noun};
+
+mod common;
+
+/// Sends `%request` requests to the HTTP client driver.
+#[test]
+fn send_request() {
+    let mut driver = common::spawn_driver("http-client");
+
+    let mut stdin = driver.stdin.take().unwrap();
+    let mut stdout = driver.stdout.take().unwrap();
+
+    // This HTTP request can be replicated from the command line:
+    //
+    // ```
+    // $ curl -i -X GET https://archlinux.org
+    // ```
+    {
+        let req_num = 87714;
+        let req = Noun::from(Cell::from([
+            // Tag.
+            Noun::from(Atom::from("request")),
+            // Request number.
+            Noun::from(Atom::from(req_num)),
+            // HTTP method.
+            Noun::from(Atom::from("GET")),
+            // HTTP URI.
+            Noun::from(Atom::from("https://archlinux.org")),
+            // HTTP headers.
+            Noun::null(),
+            // HTTP body.
+            Noun::null(),
+        ]));
+
+        common::write_request(&mut stdin, req);
+        if let Noun::Cell(resp) = common::read_response(&mut stdout) {
+            let [num, status, headers, _body] = resp.to_array::<4>().expect("response to array");
+            assert!(common::check_u64(&num, req_num));
+            assert!(common::check_u64(&status, 200));
+
+            let headers = convert!(&*headers => HashMap<&str, &str>).expect("headers to HashMap");
+
+            // We can't check the value of these headers because they aren't deterministic.
+            assert!(headers.contains_key("cache-control"));
+            assert!(headers.contains_key("content-length"));
+            assert!(headers.contains_key("date"));
+            assert!(headers.contains_key("strict-transport-security"));
+            assert!(headers.contains_key("vary"));
+            assert!(headers.contains_key("x-frame-options"));
+
+            assert_eq!(
+                headers.get("content-security-policy"),
+                Some(&"form-action 'self'; script-src 'self'; img-src 'self' data:; default-src 'self'; base-uri 'none'; frame-ancestors 'none'"),
+            );
+            assert_eq!(
+                headers.get("content-type"),
+                Some(&"text/html; charset=utf-8")
+            );
+            assert_eq!(
+                headers.get("cross-origin-opener-policy"),
+                Some(&"same-origin")
+            );
+            assert_eq!(headers.get("referrer-policy"), Some(&"strict-origin"));
+            assert_eq!(headers.get("server"), Some(&"nginx"));
+            assert_eq!(headers.get("x-content-type-options"), Some(&"nosniff"));
+        } else {
+            panic!("response is an atom");
+        }
+    }
+
+    // This HTTP request can be replicated from the command line:
+    //
+    // ```
+    // $ curl -i -X POST -H 'Content-Type: application/json' \
+    //      -d '[{"params":["0x1cb206cf43349cd6569b74aea264b3301d388aa19b083094b09ba428f925d1a5"],"id":"tx by hash","jsonrpc":"2.0","method":"eth_getTransactionByHash"}]' \
+    //      http://eth-mainnet.urbit.org:85450
+    // ```
+    {
+        let req_num = 62;
+        let req = Noun::from(Cell::from([
+            // Tag.
+            Noun::from(Atom::from("request")),
+            // Request number.
+            Noun::from(Atom::from(req_num)),
+            // HTTP method.
+            Noun::from(Atom::from("POST")),
+            // HTTP URI.
+            Noun::from(Atom::from("http://eth-mainnet.urbit.org:8545")),
+            // HTTP headers.
+            Noun::from(Cell::from([
+                Noun::from(Cell::from(["Content-Type", "application/json"])),
+                Noun::null(),
+            ])),
+            // HTTP body.
+            Noun::from(Cell::from([
+                Noun::null(),
+                Noun::from(Atom::from(153u8)),
+                Noun::from(Atom::from(
+                    r#"[{"params":["0x1cb206cf43349cd6569b74aea264b3301d388aa19b083094b09ba428f925d1a5"],"id":"tx by hash","jsonrpc":"2.0","method":"eth_getTransactionByHash"}]"#,
+                )),
+            ])),
+        ]));
+
+        common::write_request(&mut stdin, req);
+        if let Noun::Cell(resp) = common::read_response(&mut stdout) {
+            let [num, status, headers, body] = resp.to_array::<4>().expect("response to array");
+            assert!(common::check_u64(&num, req_num));
+            assert!(common::check_u64(&status, 200));
+
+            let headers = convert!(&*headers => HashMap<&str, &str>).expect("headers to HashMap");
+            // We can't check the value of these headers because they aren't deterministic.
+            assert!(headers.contains_key("x-cached"));
+            assert!(headers.contains_key("date"));
+
+            // We can't check the value of these headers because each header occurs multiple times.
+            assert!(headers.contains_key("vary"));
+
+            assert_eq!(headers.get("connection"), Some(&"keep-alive"));
+            assert_eq!(headers.get("content-type"), Some(&"application/json"));
+            assert_eq!(headers.get("server"), Some(&"nginx/1.14.0 (Ubuntu)"));
+            assert_eq!(headers.get("transfer-encoding"), Some(&"chunked"));
+
+            if let Noun::Cell(body) = &*body {
+                let [_null, body_len, _body] = body.to_array::<3>().expect("body to array");
+                assert!(common::check_u64(&body_len, 0x28c75));
+            } else {
+                panic!("body is an atom");
+            }
+        } else {
+            panic!("response is an atom");
+        }
+    }
+
+    // This HTTP request can be replicated from the command line:
+    //
+    // ```
+    // $ curl -i -X PUT https://urbit.org
+    // ```
+    {
+        let req_num = u64::MAX;
+        let req = Noun::from(Cell::from([
+            // Tag.
+            Noun::from(Atom::from("request")),
+            // Request number.
+            Noun::from(Atom::from(req_num)),
+            // HTTP method.
+            Noun::from(Atom::from("PUT")),
+            // HTTP URI.
+            Noun::from(Atom::from("https://urbit.org")),
+            // HTTP headers.
+            Noun::null(),
+            // HTTP body.
+            Noun::null(),
+        ]));
+
+        common::write_request(&mut stdin, req);
+        if let Noun::Cell(resp) = common::read_response(&mut stdout) {
+            let [num, status, _headers, _body] = resp.to_array::<4>().expect("response to array");
+            assert!(common::check_u64(&num, req_num));
+            assert!(common::check_u64(&status, 405));
+        } else {
+            panic!("response is an atom");
+        }
+    }
+}
+
+#[test]
+fn cancel_request() {
+    {}
+}


### PR DESCRIPTION
### Description

Resolves #1.

This PR improves the quality and quantity of HTTP client driver tests. In particular, it adds:
- unit tests for the `TryFrom<&Noun>` implementation for the `SendRequest` struct;
- unit tests for the `TryFrom<&Noun>` implementation for the `CancelRequest` struct;
- integration tests for the "send request" functionality; and
- integration tests for the "cancel request" functionality.

The bulk of the work that the HTTP client driver does is converting incoming requests from nouns into a format that [hyper](https://hyper.rs) understands and converting outgoing responses from a format that [hyper](https://hyper.rs) understands into nouns. The latter case--converting responses into nouns--already has at least partial coverage, and adding unit tests for the `TryFrom<&Noun>` implementations of the HTTP client driver's two request types--`SendRequest` and `CancelRequest`--means that we now have test coverage for all the most error-prone parts of the driver.

The integration tests spawn the HTTP client driver in a separate subprocess and feed it requests via the subprocess's `stdin` and consume responses via the subprocess's `stdout`. This setup is identical to the one used by the Urbit runtime (when all processes run on the same machine). The integration tests exercise "send request" functionality on a variety of HTTP methods and URIs and also the harder-to-test "cancel request" functionality.

### Related

https://github.com/urbit/runtime/issues/11