### PR TITLE
Assert existence, not value, of `content-security-policy` header

### DIFF
--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -54,15 +54,12 @@ fn send_request() {
             // We can't check the value of these headers because they aren't deterministic.
             assert!(headers.contains_key("cache-control"));
             assert!(headers.contains_key("content-length"));
+            assert!(headers.contains_key("content-security-policy"));
             assert!(headers.contains_key("date"));
             assert!(headers.contains_key("strict-transport-security"));
             assert!(headers.contains_key("vary"));
             assert!(headers.contains_key("x-frame-options"));
 
-            assert_eq!(
-                headers.get("content-security-policy"),
-                Some(&"form-action 'self'; script-src 'self'; img-src 'self' data:; default-src 'self'; base-uri 'none'; frame-ancestors 'none'"),
-            );
             assert_eq!(
                 headers.get("content-type"),
                 Some(&"text/html; charset=utf-8")

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -216,9 +216,9 @@ fn cancel_request() {
         });
 
         // Conclude that we successfully cancelled the request if we still haven't heard from the
-        // response thread in 5s.
+        // response thread in 2s.
         assert_eq!(
-            done_rx.recv_timeout(Duration::from_secs(5)),
+            done_rx.recv_timeout(Duration::from_secs(2)),
             Err(mpsc::RecvTimeoutError::Timeout),
         );
 


### PR DESCRIPTION
Resolves #5.